### PR TITLE
Modernize to latest versions supported by Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>4.51</version>
         <relativePath />
     </parent>
 
     <properties>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>1.614</jenkins.version>
+        <jenkins.version>2.346.3</jenkins.version>
         <!-- Other properties you may want to use:
              ~ java.level: set to 6 if your jenkins.version <= 1.611 ~ jenkins-test-harness.version: Jenkins Test Harness version you use to test the plugin. For Jenkins version >= 1.580.1 use JTH 2.0 or higher.
              ~ hpi-plugin.version: The HPI Maven Plugin version used by the plugin..


### PR DESCRIPTION
Hi!

This PR aims to modernize tooling and move this plugin closer to the [recommended Jenkins baseline version](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/) without making the change too big. If this goes well, I can follow up with a subsequent PR to modernize further.

Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.ModernizePluginForJava8